### PR TITLE
doc: Fix example for xapi.Verb.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,8 +464,8 @@ var verbData = {
 };
 
 // then create the verb from the verbData object
-var myVerb = xapi.StatementQuery(verbData);
+var myVerb = xapi.Verb.create(verbData);
 
 // alternatively, build a verb from individual peices
-var myVerb = xapi.StatementQuery(id, display);
+var myVerb = xapi.Verb.create(id, display);
 ```


### PR DESCRIPTION
This was using `StatementQuery` rather than `Verb when creating a verb.